### PR TITLE
Surface panics from user closures as Error::Panic

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -109,6 +109,41 @@ enum Command {
     Shutdown(Box<dyn FnOnce(Result<(), Error>) + Send>),
 }
 
+fn run_catching<F, T>(func: F) -> Result<T, Error>
+where
+    F: FnOnce() -> Result<T, rusqlite::Error>,
+{
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(func)) {
+        Ok(res) => res.map_err(Error::from),
+        Err(p) => Err(Error::Panic {
+            message: panic_message(&*p),
+        }),
+    }
+}
+
+fn run_catching_and_then<F, T, E>(func: F) -> Result<T, E>
+where
+    F: FnOnce() -> Result<T, E>,
+    E: From<Error>,
+{
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(func)) {
+        Ok(res) => res,
+        Err(p) => Err(E::from(Error::Panic {
+            message: panic_message(&*p),
+        })),
+    }
+}
+
+fn panic_message(p: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = p.downcast_ref::<&'static str>() {
+        (*s).to_owned()
+    } else if let Some(s) = p.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "panic".to_owned()
+    }
+}
+
 /// Client represents a single sqlite connection that can be used from async
 /// contexts.
 #[derive(Clone)]
@@ -153,11 +188,7 @@ impl Client {
 
             while let Ok(cmd) = conn_rx.recv() {
                 match cmd {
-                    Command::Func(func) => {
-                        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                            func(&mut conn);
-                        }));
-                    }
+                    Command::Func(func) => func(&mut conn),
                     Command::Shutdown(func) => match conn.close() {
                         Ok(()) => {
                             func(Ok(()));
@@ -205,9 +236,9 @@ impl Client {
     {
         let (tx, rx) = oneshot::channel();
         self.conn_tx.send(Command::Func(Box::new(move |conn| {
-            _ = tx.send(func(conn));
+            _ = tx.send(run_catching(|| func(conn)));
         })))?;
-        Ok(rx.await??)
+        rx.await?
     }
 
     /// Invokes the provided function with a mutable [`rusqlite::Connection`].
@@ -218,9 +249,9 @@ impl Client {
     {
         let (tx, rx) = oneshot::channel();
         self.conn_tx.send(Command::Func(Box::new(move |conn| {
-            _ = tx.send(func(conn));
+            _ = tx.send(run_catching(|| func(conn)));
         })))?;
-        Ok(rx.await??)
+        rx.await?
     }
 
     /// Invokes the provided function with a [`rusqlite::Connection`].
@@ -236,7 +267,7 @@ impl Client {
         let (tx, rx) = oneshot::channel();
         self.conn_tx
             .send(Command::Func(Box::new(move |conn| {
-                _ = tx.send(func(conn));
+                _ = tx.send(run_catching_and_then(|| func(conn)));
             })))
             .map_err(Error::from)?;
         rx.await.map_err(Error::from)?
@@ -255,7 +286,7 @@ impl Client {
         let (tx, rx) = oneshot::channel();
         self.conn_tx
             .send(Command::Func(Box::new(move |conn| {
-                _ = tx.send(func(conn));
+                _ = tx.send(run_catching_and_then(|| func(conn)));
             })))
             .map_err(Error::from)?;
         rx.await.map_err(Error::from)?
@@ -285,9 +316,9 @@ impl Client {
     {
         let (tx, rx) = bounded(1);
         self.conn_tx.send(Command::Func(Box::new(move |conn| {
-            _ = tx.send(func(conn));
+            _ = tx.send(run_catching(|| func(conn)));
         })))?;
-        Ok(rx.recv()??)
+        rx.recv()?
     }
 
     /// Invokes the provided function with a mutable [`rusqlite::Connection`],
@@ -299,9 +330,9 @@ impl Client {
     {
         let (tx, rx) = bounded(1);
         self.conn_tx.send(Command::Func(Box::new(move |conn| {
-            _ = tx.send(func(conn));
+            _ = tx.send(run_catching(|| func(conn)));
         })))?;
-        Ok(rx.recv()??)
+        rx.recv()?
     }
 
     /// Closes the underlying sqlite connection, blocking the current thread

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,8 @@ pub enum Error {
     },
     /// Represents a [`rusqlite::Error`].
     Rusqlite(rusqlite::Error),
+    /// A user-provided closure panicked while being executed on the worker thread.
+    Panic { message: String },
 }
 
 impl std::error::Error for Error {
@@ -31,6 +33,7 @@ impl std::fmt::Display for Error {
                 write!(f, "updating pragma {name}: expected '{exp}', got '{got}'")
             }
             Error::Rusqlite(err) => err.fmt(f),
+            Error::Panic { message } => write!(f, "user closure panicked: {message}"),
         }
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -87,6 +87,7 @@ async_test!(test_pool_journal_mode);
 async_test!(test_pool_conn_for_each);
 async_test!(test_pool_close_concurrent);
 async_test!(test_pool_num_conns_zero_clamps);
+async_test!(test_closure_panic_surfaces_error);
 
 async fn test_journal_mode() {
     let tmp_dir = tempfile::tempdir().unwrap();
@@ -275,6 +276,37 @@ async fn test_pool_close_concurrent() {
 
     let res = pool.conn(|c| c.execute("SELECT 1", ())).await;
     assert!(matches!(res, Err(Error::Closed)));
+}
+
+async fn test_closure_panic_surfaces_error() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let client = ClientBuilder::new()
+        .path(tmp_dir.path().join("sqlite.db"))
+        .open()
+        .await
+        .expect("client unable to be opened");
+
+    let res: Result<(), Error> = client.conn(|_| panic!("boom: &str")).await;
+    match res {
+        Err(Error::Panic { message }) => assert!(message.contains("boom"), "got {message}"),
+        other => panic!("expected Error::Panic, got {other:?}"),
+    }
+
+    let res: Result<(), Error> = client
+        .conn(|_| panic!("{}", String::from("boom: String")))
+        .await;
+    match res {
+        Err(Error::Panic { message }) => assert!(message.contains("boom"), "got {message}"),
+        other => panic!("expected Error::Panic, got {other:?}"),
+    }
+
+    // Connection must remain usable after a panic.
+    client
+        .conn(|conn| conn.query_row("SELECT 1", (), |row| row.get::<_, i64>(0)))
+        .await
+        .expect("connection still usable after panic");
+
+    client.close().await.expect("closing client");
 }
 
 async fn test_pool_num_conns_zero_clamps() {


### PR DESCRIPTION
Previously, when a closure passed to conn/conn_mut (and friends) panicked, the worker thread would swallow it via catch_unwind, drop the oneshot sender, and the caller would see Error::Closed — even though the connection was still healthy. Add a new Error::Panic variant and wrap each user closure so panic payloads are downcast to a message and forwarded through the result channel.