### PR TITLE
Make queued client operations cancellation-aware and bounded

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,11 +26,11 @@ The minimum supported Rust version is 1.95.0.
 
 The library has three core types in `src/`:
 
-- **Client** (`client.rs`): Wraps a single SQLite connection. Spawns a background `std::thread` that receives commands (closures) via a `crossbeam_channel`. Results are returned through `futures_channel::oneshot`. This design makes it runtime-agnostic. Client is cheaply cloneable.
+- **Client** (`client.rs`): Wraps a single SQLite connection. Spawns a background `std::thread` that receives commands (closures) via a `crossbeam_channel`. Results are returned through `futures_channel::oneshot`. Queued async commands are skipped if their reply channel is already canceled, and `ClientBuilder::queue_capacity()` can bound the worker queue. This design makes it runtime-agnostic. Client is cheaply cloneable.
 
-- **Pool** (`pool.rs`): Manages multiple `Client` instances with round-robin selection via an atomic counter. Provides the same API as Client plus `conn_for_each()` for executing on all connections. File-backed and named shared-memory pools default to CPU-count connections; anonymous in-memory pools default to one connection and reject explicit multi-connection configuration.
+- **Pool** (`pool.rs`): Manages multiple `Client` instances with round-robin selection via an atomic counter. Provides the same API as Client plus `conn_for_each()` for executing on all connections. File-backed and named shared-memory pools default to CPU-count connections; anonymous in-memory pools default to one connection and reject explicit multi-connection configuration. `PoolBuilder::queue_capacity()` applies the same per-client queue bound to every pool connection.
 
-- **Error** (`error.rs`): Non-exhaustive enum wrapping config errors, `rusqlite::Error`, channel errors, panics, and pragma failures.
+- **Error** (`error.rs`): Non-exhaustive enum wrapping config errors, queue-full errors, `rusqlite::Error`, channel errors, panics, and pragma failures.
 
 All database operations use a closure-based API (e.g., `conn(|conn| { ... })`) to avoid lifetime issues with the cross-thread boundary. Both blocking and async variants exist for all operations.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ let value: String = client.conn(|conn| {
 println!("Value is: {value}");
 ```
 
+Async operations that are queued and then canceled before the worker starts
+them are skipped. `ClientBuilder::queue_capacity()` and
+`PoolBuilder::queue_capacity()` can be used to bound worker queues; operations
+return `Error::QueueFull` when the selected queue is full.
+
 A `Pool` represents a collection of background sqlite3 connections that can be
 called concurrently from any thread in your program.
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::Error;
 
-use crossbeam_channel::{bounded, unbounded, Sender};
+use crossbeam_channel::{bounded, unbounded, Receiver, Sender, TrySendError};
 use futures_channel::oneshot;
 use rusqlite::{Connection, OpenFlags};
 
@@ -34,6 +34,7 @@ pub struct ClientBuilder {
     pub(crate) flags: OpenFlags,
     pub(crate) journal_mode: Option<JournalMode>,
     pub(crate) vfs: Option<String>,
+    pub(crate) queue_capacity: Option<usize>,
 }
 
 impl ClientBuilder {
@@ -72,6 +73,17 @@ impl ClientBuilder {
         self
     }
 
+    /// Limit the number of commands that may wait in the worker queue.
+    ///
+    /// By default, the queue is unbounded. If a capacity is configured, calls
+    /// return [`Error::QueueFull`] when that many commands are already waiting
+    /// for the worker thread. A capacity of `0` allows a command to be accepted
+    /// only when the worker is ready to receive it immediately.
+    pub fn queue_capacity(mut self, queue_capacity: usize) -> Self {
+        self.queue_capacity = Some(queue_capacity);
+        self
+    }
+
     /// Returns a new [`Client`] that uses the `ClientBuilder` configuration.
     ///
     /// # Examples
@@ -105,8 +117,88 @@ impl ClientBuilder {
 }
 
 enum Command {
-    Func(Box<dyn FnOnce(&mut Connection) + Send>),
-    Shutdown(Box<dyn FnOnce(Result<(), Error>) + Send>),
+    Func(Box<dyn QueuedFunc>),
+    Shutdown(Box<dyn QueuedShutdown>),
+}
+
+trait QueuedFunc: Send {
+    fn is_canceled(&self) -> bool;
+    fn execute(self: Box<Self>, conn: &mut Connection);
+}
+
+struct AsyncFunc<F, T, E> {
+    tx: oneshot::Sender<Result<T, E>>,
+    func: F,
+}
+
+impl<F, T, E> QueuedFunc for AsyncFunc<F, T, E>
+where
+    F: FnOnce(&mut Connection) -> Result<T, E> + Send + 'static,
+    T: Send + 'static,
+    E: Send + 'static,
+{
+    fn is_canceled(&self) -> bool {
+        self.tx.is_canceled()
+    }
+
+    fn execute(self: Box<Self>, conn: &mut Connection) {
+        let Self { tx, func } = *self;
+        _ = tx.send(func(conn));
+    }
+}
+
+struct BlockingFunc<F, T, E> {
+    tx: Sender<Result<T, E>>,
+    func: F,
+}
+
+impl<F, T, E> QueuedFunc for BlockingFunc<F, T, E>
+where
+    F: FnOnce(&mut Connection) -> Result<T, E> + Send + 'static,
+    T: Send + 'static,
+    E: Send + 'static,
+{
+    fn is_canceled(&self) -> bool {
+        false
+    }
+
+    fn execute(self: Box<Self>, conn: &mut Connection) {
+        let Self { tx, func } = *self;
+        _ = tx.send(func(conn));
+    }
+}
+
+trait QueuedShutdown: Send {
+    fn is_canceled(&self) -> bool;
+    fn respond(self: Box<Self>, res: Result<(), Error>);
+}
+
+struct AsyncShutdown {
+    tx: oneshot::Sender<Result<(), Error>>,
+}
+
+impl QueuedShutdown for AsyncShutdown {
+    fn is_canceled(&self) -> bool {
+        self.tx.is_canceled()
+    }
+
+    fn respond(self: Box<Self>, res: Result<(), Error>) {
+        _ = self.tx.send(res);
+    }
+}
+
+struct BlockingShutdown {
+    tx: Sender<Result<(), Error>>,
+}
+
+impl QueuedShutdown for BlockingShutdown {
+    fn is_canceled(&self) -> bool {
+        false
+    }
+
+    fn respond(self: Box<Self>, res: Result<(), Error>) {
+        _ = self.tx.send(res);
+    }
 }
 
 fn run_catching<F, T>(conn: &mut Connection, func: F) -> Result<T, Error>
@@ -185,7 +277,10 @@ impl Client {
         F: FnOnce(Result<Self, Error>) + Send + 'static,
     {
         thread::spawn(move || {
-            let (conn_tx, conn_rx) = unbounded();
+            let (conn_tx, conn_rx) = match builder.queue_capacity {
+                Some(queue_capacity) => bounded(queue_capacity),
+                None => unbounded(),
+            };
 
             let mut conn = match Client::create_conn(builder) {
                 Ok(conn) => conn,
@@ -200,17 +295,25 @@ impl Client {
 
             while let Ok(cmd) = conn_rx.recv() {
                 match cmd {
-                    Command::Func(func) => func(&mut conn),
-                    Command::Shutdown(func) => match conn.close() {
-                        Ok(()) => {
-                            func(Ok(()));
-                            return;
+                    Command::Func(func) => {
+                        if !func.is_canceled() {
+                            func.execute(&mut conn);
                         }
-                        Err((c, e)) => {
-                            conn = c;
-                            func(Err(e.into()));
+                    }
+                    Command::Shutdown(func) => {
+                        if !func.is_canceled() {
+                            match conn.close() {
+                                Ok(()) => {
+                                    func.respond(Ok(()));
+                                    return;
+                                }
+                                Err((c, e)) => {
+                                    conn = c;
+                                    func.respond(Err(e.into()));
+                                }
+                            }
                         }
-                    },
+                    }
                 }
             }
         });
@@ -240,16 +343,45 @@ impl Client {
         Ok(conn)
     }
 
+    fn enqueue_async<F, T, E>(
+        &self,
+        func: F,
+    ) -> Result<oneshot::Receiver<Result<T, E>>, TrySendError<Command>>
+    where
+        F: FnOnce(&mut Connection) -> Result<T, E> + Send + 'static,
+        T: Send + 'static,
+        E: Send + 'static,
+    {
+        let (tx, rx) = oneshot::channel();
+        self.conn_tx
+            .try_send(Command::Func(Box::new(AsyncFunc { tx, func })))?;
+        Ok(rx)
+    }
+
+    fn enqueue_blocking<F, T, E>(
+        &self,
+        func: F,
+    ) -> Result<Receiver<Result<T, E>>, TrySendError<Command>>
+    where
+        F: FnOnce(&mut Connection) -> Result<T, E> + Send + 'static,
+        T: Send + 'static,
+        E: Send + 'static,
+    {
+        let (tx, rx) = bounded(1);
+        self.conn_tx
+            .try_send(Command::Func(Box::new(BlockingFunc { tx, func })))?;
+        Ok(rx)
+    }
+
     /// Invokes the provided function with a [`rusqlite::Connection`].
     pub async fn conn<F, T>(&self, func: F) -> Result<T, Error>
     where
         F: FnOnce(&Connection) -> Result<T, rusqlite::Error> + Send + 'static,
         T: Send + 'static,
     {
-        let (tx, rx) = oneshot::channel();
-        self.conn_tx.send(Command::Func(Box::new(move |conn| {
-            _ = tx.send(run_catching(conn, |conn| func(conn)));
-        })))?;
+        let rx = self
+            .enqueue_async(move |conn| run_catching(conn, |conn| func(conn)))
+            .map_err(Error::from)?;
         rx.await?
     }
 
@@ -259,10 +391,9 @@ impl Client {
         F: FnOnce(&mut Connection) -> Result<T, rusqlite::Error> + Send + 'static,
         T: Send + 'static,
     {
-        let (tx, rx) = oneshot::channel();
-        self.conn_tx.send(Command::Func(Box::new(move |conn| {
-            _ = tx.send(run_catching(conn, func));
-        })))?;
+        let rx = self
+            .enqueue_async(move |conn| run_catching(conn, func))
+            .map_err(Error::from)?;
         rx.await?
     }
 
@@ -276,11 +407,8 @@ impl Client {
         T: Send + 'static,
         E: From<rusqlite::Error> + From<Error> + Send + 'static,
     {
-        let (tx, rx) = oneshot::channel();
-        self.conn_tx
-            .send(Command::Func(Box::new(move |conn| {
-                _ = tx.send(run_catching_and_then(conn, |conn| func(conn)));
-            })))
+        let rx = self
+            .enqueue_async(move |conn| run_catching_and_then(conn, |conn| func(conn)))
             .map_err(Error::from)?;
         rx.await.map_err(Error::from)?
     }
@@ -295,11 +423,8 @@ impl Client {
         T: Send + 'static,
         E: From<rusqlite::Error> + From<Error> + Send + 'static,
     {
-        let (tx, rx) = oneshot::channel();
-        self.conn_tx
-            .send(Command::Func(Box::new(move |conn| {
-                _ = tx.send(run_catching_and_then(conn, func));
-            })))
+        let rx = self
+            .enqueue_async(move |conn| run_catching_and_then(conn, func))
             .map_err(Error::from)?;
         rx.await.map_err(Error::from)?
     }
@@ -310,10 +435,16 @@ impl Client {
     /// `self::conn_mut()` will return an [`Error::Closed`] error.
     pub async fn close(&self) -> Result<(), Error> {
         let (tx, rx) = oneshot::channel();
-        let func = Box::new(|res| _ = tx.send(res));
-        if self.conn_tx.send(Command::Shutdown(func)).is_err() {
-            // If the worker thread has already shut down, return Ok here.
-            return Ok(());
+        match self
+            .conn_tx
+            .try_send(Command::Shutdown(Box::new(AsyncShutdown { tx })))
+        {
+            Ok(()) => {}
+            Err(TrySendError::Disconnected(_)) => {
+                // If the worker thread has already shut down, return Ok here.
+                return Ok(());
+            }
+            Err(err) => return Err(err.into()),
         }
         // If receiving fails, the connection is already closed.
         rx.await.unwrap_or(Ok(()))
@@ -326,10 +457,9 @@ impl Client {
         F: FnOnce(&Connection) -> Result<T, rusqlite::Error> + Send + 'static,
         T: Send + 'static,
     {
-        let (tx, rx) = bounded(1);
-        self.conn_tx.send(Command::Func(Box::new(move |conn| {
-            _ = tx.send(run_catching(conn, |conn| func(conn)));
-        })))?;
+        let rx = self
+            .enqueue_blocking(move |conn| run_catching(conn, |conn| func(conn)))
+            .map_err(Error::from)?;
         rx.recv()?
     }
 
@@ -340,10 +470,9 @@ impl Client {
         F: FnOnce(&mut Connection) -> Result<T, rusqlite::Error> + Send + 'static,
         T: Send + 'static,
     {
-        let (tx, rx) = bounded(1);
-        self.conn_tx.send(Command::Func(Box::new(move |conn| {
-            _ = tx.send(run_catching(conn, func));
-        })))?;
+        let rx = self
+            .enqueue_blocking(move |conn| run_catching(conn, func))
+            .map_err(Error::from)?;
         rx.recv()?
     }
 
@@ -354,9 +483,13 @@ impl Client {
     /// `self::conn_mut_blocking()` will return an [`Error::Closed`] error.
     pub fn close_blocking(&self) -> Result<(), Error> {
         let (tx, rx) = bounded(1);
-        let func = Box::new(move |res| _ = tx.send(res));
-        if self.conn_tx.send(Command::Shutdown(func)).is_err() {
-            return Ok(());
+        match self
+            .conn_tx
+            .try_send(Command::Shutdown(Box::new(BlockingShutdown { tx })))
+        {
+            Ok(()) => {}
+            Err(TrySendError::Disconnected(_)) => return Ok(()),
+            Err(err) => return Err(err.into()),
         }
         // If receiving fails, the connection is already closed.
         rx.recv().unwrap_or(Ok(()))

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,8 @@
 pub enum Error {
     /// Indicates that the connection to the sqlite database is closed.
     Closed,
+    /// Indicates that the sqlite worker queue is full.
+    QueueFull,
     /// Invalid builder configuration.
     Config { message: &'static str },
     /// Error updating PRAGMA.
@@ -31,6 +33,7 @@ impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::Closed => write!(f, "connection to sqlite database closed"),
+            Error::QueueFull => write!(f, "sqlite worker queue is full"),
             Error::Config { message } => write!(f, "invalid configuration: {message}"),
             Error::PragmaUpdate { exp, got, name } => {
                 write!(f, "updating pragma {name}: expected '{exp}', got '{got}'")
@@ -50,6 +53,15 @@ impl From<rusqlite::Error> for Error {
 impl<T> From<crossbeam_channel::SendError<T>> for Error {
     fn from(_value: crossbeam_channel::SendError<T>) -> Self {
         Error::Closed
+    }
+}
+
+impl<T> From<crossbeam_channel::TrySendError<T>> for Error {
+    fn from(value: crossbeam_channel::TrySendError<T>) -> Self {
+        match value {
+            crossbeam_channel::TrySendError::Full(_) => Error::QueueFull,
+            crossbeam_channel::TrySendError::Disconnected(_) => Error::Closed,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,11 @@
 //! }
 //! ```
 //!
+//! Async operations that are queued and then canceled before the worker starts
+//! them are skipped. [`ClientBuilder::queue_capacity()`] and
+//! [`PoolBuilder::queue_capacity()`] can be used to bound worker queues;
+//! operations return [`Error::QueueFull`] when the selected queue is full.
+//!
 //! A `Pool` represents a collection of background sqlite3 connections that can be
 //! called concurrently from any thread in your program.
 //!

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -39,6 +39,7 @@ pub struct PoolBuilder {
     journal_mode: Option<JournalMode>,
     vfs: Option<String>,
     num_conns: Option<usize>,
+    queue_capacity: Option<usize>,
 }
 
 impl PoolBuilder {
@@ -116,6 +117,19 @@ impl PoolBuilder {
     /// ```
     pub fn num_conns(mut self, num_conns: usize) -> Self {
         self.num_conns = Some(num_conns.max(1));
+        self
+    }
+
+    /// Limit the number of commands that may wait in each connection's worker
+    /// queue.
+    ///
+    /// By default, each queue is unbounded. If a capacity is configured, calls
+    /// return [`Error::QueueFull`] when a selected connection already has that
+    /// many commands waiting for its worker thread. A capacity of `0` allows a
+    /// command to be accepted only when the worker is ready to receive it
+    /// immediately.
+    pub fn queue_capacity(mut self, queue_capacity: usize) -> Self {
+        self.queue_capacity = Some(queue_capacity);
         self
     }
 
@@ -234,6 +248,7 @@ impl PoolBuilder {
             flags: self.connection_flags(),
             journal_mode: self.journal_mode,
             vfs: self.vfs.clone(),
+            queue_capacity: self.queue_capacity,
         }
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use async_sqlite::{ClientBuilder, Error, JournalMode, PoolBuilder};
+use futures_util::FutureExt;
 
 static SHARED_MEMORY_ID: AtomicUsize = AtomicUsize::new(0);
 
@@ -213,6 +214,8 @@ async_test!(test_shared_memory_rejects_empty_name);
 async_test!(test_pool_journal_mode);
 async_test!(test_pool_conn_for_each);
 async_test!(test_pool_close_concurrent);
+async_test!(test_canceled_async_command_is_skipped);
+async_test!(test_client_queue_capacity_reports_full);
 async_test!(test_pool_num_conns_zero_clamps);
 async_test!(test_closure_panic_surfaces_error);
 async_test!(test_panic_after_begin_immediate_rolls_back);
@@ -533,6 +536,81 @@ async fn test_pool_close_concurrent() {
 
     let res = pool.conn(|c| c.execute("SELECT 1", ())).await;
     assert!(matches!(res, Err(Error::Closed)));
+}
+
+async fn test_canceled_async_command_is_skipped() {
+    let client = ClientBuilder::new()
+        .open()
+        .await
+        .expect("client unable to be opened");
+
+    client
+        .conn(|conn| {
+            conn.execute("CREATE TABLE testing (id INTEGER PRIMARY KEY)", ())?;
+            Ok(())
+        })
+        .await
+        .expect("creating table");
+
+    let (started_tx, started_rx) = std::sync::mpsc::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let mut blocker = Box::pin(client.conn(move |_| {
+        started_tx.send(()).expect("notifying blocker started");
+        release_rx.recv().expect("waiting for blocker release");
+        Ok(())
+    }));
+
+    assert!(blocker.as_mut().now_or_never().is_none());
+    started_rx.recv().expect("waiting for blocker to start");
+
+    let mut canceled = Box::pin(client.conn(|conn| {
+        conn.execute("INSERT INTO testing VALUES (1)", ())?;
+        Ok(())
+    }));
+    assert!(canceled.as_mut().now_or_never().is_none());
+    drop(canceled);
+
+    release_tx.send(()).expect("releasing blocker");
+    blocker.await.expect("blocker finished");
+
+    let row_count: i64 = client
+        .conn(|conn| conn.query_row("SELECT COUNT(*) FROM testing", (), |row| row.get(0)))
+        .await
+        .expect("counting rows");
+    assert_eq!(row_count, 0);
+
+    client.close().await.expect("closing client");
+}
+
+async fn test_client_queue_capacity_reports_full() {
+    let client = ClientBuilder::new()
+        .queue_capacity(1)
+        .open()
+        .await
+        .expect("client unable to be opened");
+
+    let (started_tx, started_rx) = std::sync::mpsc::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let mut blocker = Box::pin(client.conn(move |_| {
+        started_tx.send(()).expect("notifying blocker started");
+        release_rx.recv().expect("waiting for blocker release");
+        Ok(())
+    }));
+
+    assert!(blocker.as_mut().now_or_never().is_none());
+    started_rx.recv().expect("waiting for blocker to start");
+
+    let mut queued = Box::pin(client.conn(|_| Ok(())));
+    assert!(queued.as_mut().now_or_never().is_none());
+
+    let res: Result<(), Error> = client.conn(|_| Ok(())).await;
+    assert!(matches!(res, Err(Error::QueueFull)));
+
+    release_tx.send(()).expect("releasing blocker");
+    blocker.await.expect("blocker finished");
+    queued.await.expect("queued command finished");
+
+    client.close().await.expect("closing client");
 }
 
 async fn test_closure_panic_surfaces_error() {


### PR DESCRIPTION
## Summary
- Skip queued async commands when their reply `oneshot` has already been canceled, so dropped or timed-out futures do not run later.
- Add `ClientBuilder::queue_capacity()` and `PoolBuilder::queue_capacity()` to bound worker queues.
- Return `Error::QueueFull` when a bounded queue is saturated, and switch enqueue paths to nonblocking `try_send`.
- Add regression coverage for canceled queued work and full-queue behavior.

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy -- -D warnings`