### PR TITLE
Add Pool custom-error APIs and blocking client variants

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -476,6 +476,40 @@ impl Client {
         rx.recv()?
     }
 
+    /// Invokes the provided function with a [`rusqlite::Connection`],
+    /// blocking the current thread until completion.
+    ///
+    /// Maps the result error type to a custom error; designed to be
+    /// used in conjunction with [`query_and_then`](https://docs.rs/rusqlite/latest/rusqlite/struct.CachedStatement.html#method.query_and_then).
+    pub fn conn_and_then_blocking<F, T, E>(&self, func: F) -> Result<T, E>
+    where
+        F: FnOnce(&Connection) -> Result<T, E> + Send + 'static,
+        T: Send + 'static,
+        E: From<rusqlite::Error> + From<Error> + Send + 'static,
+    {
+        let rx = self
+            .enqueue_blocking(move |conn| run_catching_and_then(conn, |conn| func(conn)))
+            .map_err(Error::from)?;
+        rx.recv().map_err(Error::from)?
+    }
+
+    /// Invokes the provided function with a mutable [`rusqlite::Connection`],
+    /// blocking the current thread until completion.
+    ///
+    /// Maps the result error type to a custom error; designed to be
+    /// used in conjunction with [`query_and_then`](https://docs.rs/rusqlite/latest/rusqlite/struct.CachedStatement.html#method.query_and_then).
+    pub fn conn_mut_and_then_blocking<F, T, E>(&self, func: F) -> Result<T, E>
+    where
+        F: FnOnce(&mut Connection) -> Result<T, E> + Send + 'static,
+        T: Send + 'static,
+        E: From<rusqlite::Error> + From<Error> + Send + 'static,
+    {
+        let rx = self
+            .enqueue_blocking(move |conn| run_catching_and_then(conn, func))
+            .map_err(Error::from)?;
+        rx.recv().map_err(Error::from)?
+    }
+
     /// Closes the underlying sqlite connection, blocking the current thread
     /// until complete.
     ///

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -334,6 +334,32 @@ impl Pool {
         self.get().conn_mut(func).await
     }
 
+    /// Invokes the provided function with a [`rusqlite::Connection`].
+    ///
+    /// Maps the result error type to a custom error; designed to be
+    /// used in conjunction with [`query_and_then`](https://docs.rs/rusqlite/latest/rusqlite/struct.CachedStatement.html#method.query_and_then).
+    pub async fn conn_and_then<F, T, E>(&self, func: F) -> Result<T, E>
+    where
+        F: FnOnce(&Connection) -> Result<T, E> + Send + 'static,
+        T: Send + 'static,
+        E: From<rusqlite::Error> + From<Error> + Send + 'static,
+    {
+        self.get().conn_and_then(func).await
+    }
+
+    /// Invokes the provided function with a mutable [`rusqlite::Connection`].
+    ///
+    /// Maps the result error type to a custom error; designed to be
+    /// used in conjunction with [`query_and_then`](https://docs.rs/rusqlite/latest/rusqlite/struct.CachedStatement.html#method.query_and_then).
+    pub async fn conn_mut_and_then<F, T, E>(&self, func: F) -> Result<T, E>
+    where
+        F: FnOnce(&mut Connection) -> Result<T, E> + Send + 'static,
+        T: Send + 'static,
+        E: From<rusqlite::Error> + From<Error> + Send + 'static,
+    {
+        self.get().conn_mut_and_then(func).await
+    }
+
     /// Closes the underlying sqlite connections.
     ///
     /// After this method returns, all calls to `self::conn()` or
@@ -363,6 +389,34 @@ impl Pool {
         T: Send + 'static,
     {
         self.get().conn_mut_blocking(func)
+    }
+
+    /// Invokes the provided function with a [`rusqlite::Connection`], blocking
+    /// the current thread.
+    ///
+    /// Maps the result error type to a custom error; designed to be
+    /// used in conjunction with [`query_and_then`](https://docs.rs/rusqlite/latest/rusqlite/struct.CachedStatement.html#method.query_and_then).
+    pub fn conn_and_then_blocking<F, T, E>(&self, func: F) -> Result<T, E>
+    where
+        F: FnOnce(&Connection) -> Result<T, E> + Send + 'static,
+        T: Send + 'static,
+        E: From<rusqlite::Error> + From<Error> + Send + 'static,
+    {
+        self.get().conn_and_then_blocking(func)
+    }
+
+    /// Invokes the provided function with a mutable [`rusqlite::Connection`],
+    /// blocking the current thread.
+    ///
+    /// Maps the result error type to a custom error; designed to be
+    /// used in conjunction with [`query_and_then`](https://docs.rs/rusqlite/latest/rusqlite/struct.CachedStatement.html#method.query_and_then).
+    pub fn conn_mut_and_then_blocking<F, T, E>(&self, func: F) -> Result<T, E>
+    where
+        F: FnOnce(&mut Connection) -> Result<T, E> + Send + 'static,
+        T: Send + 'static,
+        E: From<rusqlite::Error> + From<Error> + Send + 'static,
+    {
+        self.get().conn_mut_and_then_blocking(func)
     }
 
     /// Closes the underlying sqlite connections, blocking the current thread.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -28,6 +28,32 @@ fn journal_modes() -> [(JournalMode, &'static str); 6] {
     ]
 }
 
+#[derive(Debug)]
+enum CustomError {
+    AsyncSqlite,
+    Rusqlite,
+    User(&'static str),
+}
+
+impl From<Error> for CustomError {
+    fn from(_value: Error) -> Self {
+        Self::AsyncSqlite
+    }
+}
+
+impl From<rusqlite::Error> for CustomError {
+    fn from(_value: rusqlite::Error) -> Self {
+        Self::Rusqlite
+    }
+}
+
+fn assert_user_error(result: Result<(), CustomError>, expected: &'static str) {
+    match result {
+        Err(CustomError::User(actual)) => assert_eq!(actual, expected),
+        other => panic!("expected CustomError::User({expected:?}), got {other:?}"),
+    }
+}
+
 #[test]
 fn test_blocking_client() {
     let tmp_dir = tempfile::tempdir().unwrap();
@@ -55,6 +81,39 @@ fn test_blocking_client() {
             Ok(())
         })
         .expect("querying for result");
+
+    client.close_blocking().expect("closing client conn");
+}
+
+#[test]
+fn test_blocking_client_and_then_api() {
+    let client = ClientBuilder::new()
+        .open_blocking()
+        .expect("client unable to be opened");
+
+    client
+        .conn_and_then_blocking(|conn| {
+            conn.execute(
+                "CREATE TABLE testing (id INTEGER PRIMARY KEY, val INTEGER NOT NULL)",
+                (),
+            )?;
+            conn.execute("INSERT INTO testing VALUES (1, ?)", [42])?;
+            Ok::<(), CustomError>(())
+        })
+        .expect("writing schema and seed data");
+
+    let val: i64 = client
+        .conn_mut_and_then_blocking(|conn| {
+            conn.query_row("SELECT val FROM testing WHERE id=?", [1], |row| row.get(0))
+                .map_err(CustomError::from)
+        })
+        .expect("querying for result");
+    assert_eq!(val, 42);
+
+    assert_user_error(
+        client.conn_and_then_blocking(|_| Err(CustomError::User("client"))),
+        "client",
+    );
 
     client.close_blocking().expect("closing client conn");
 }
@@ -123,6 +182,38 @@ fn test_blocking_pool() {
     .expect("querying for result");
 
     pool.close_blocking().expect("closing client conn");
+}
+
+#[test]
+fn test_blocking_pool_and_then_api() {
+    let pool = PoolBuilder::new()
+        .open_blocking()
+        .expect("pool unable to be opened");
+
+    pool.conn_and_then_blocking(|conn| {
+        conn.execute(
+            "CREATE TABLE testing (id INTEGER PRIMARY KEY, val INTEGER NOT NULL)",
+            (),
+        )?;
+        conn.execute("INSERT INTO testing VALUES (1, ?)", [42])?;
+        Ok::<(), CustomError>(())
+    })
+    .expect("writing schema and seed data");
+
+    let val: i64 = pool
+        .conn_mut_and_then_blocking(|conn| {
+            conn.query_row("SELECT val FROM testing WHERE id=?", [1], |row| row.get(0))
+                .map_err(CustomError::from)
+        })
+        .expect("querying for result");
+    assert_eq!(val, 42);
+
+    assert_user_error(
+        pool.conn_and_then_blocking(|_| Err(CustomError::User("pool"))),
+        "pool",
+    );
+
+    pool.close_blocking().expect("closing pool");
 }
 
 #[test]
@@ -208,6 +299,7 @@ async_test!(test_journal_mode);
 async_test!(test_concurrency);
 async_test!(test_default_pool_in_memory_uses_one_connection);
 async_test!(test_pool);
+async_test!(test_pool_and_then_api);
 async_test!(test_pool_rejects_multi_connection_anonymous_memory);
 async_test!(test_shared_memory_pool);
 async_test!(test_shared_memory_rejects_empty_name);
@@ -344,6 +436,41 @@ async fn test_pool() {
         .into_iter()
         .collect::<Result<(), Error>>()
         .expect("collecting query results");
+}
+
+async fn test_pool_and_then_api() {
+    let pool = PoolBuilder::new()
+        .open()
+        .await
+        .expect("pool unable to be opened");
+
+    pool.conn_and_then(|conn| {
+        conn.execute(
+            "CREATE TABLE testing (id INTEGER PRIMARY KEY, val INTEGER NOT NULL)",
+            (),
+        )?;
+        conn.execute("INSERT INTO testing VALUES (1, ?)", [42])?;
+        Ok::<(), CustomError>(())
+    })
+    .await
+    .expect("writing schema and seed data");
+
+    let val: i64 = pool
+        .conn_mut_and_then(|conn| {
+            conn.query_row("SELECT val FROM testing WHERE id=?", [1], |row| row.get(0))
+                .map_err(CustomError::from)
+        })
+        .await
+        .expect("querying for result");
+    assert_eq!(val, 42);
+
+    assert_user_error(
+        pool.conn_and_then(|_| Err(CustomError::User("pool async")))
+            .await,
+        "pool async",
+    );
+
+    pool.close().await.expect("closing pool");
 }
 
 async fn test_pool_rejects_multi_connection_anonymous_memory() {


### PR DESCRIPTION
## Summary
- Added the missing `Pool::conn_and_then` and `Pool::conn_mut_and_then` methods, delegating through `self.get()` to match the `Client` API.
- Added blocking custom-error variants on `Client` and `Pool`: `conn_and_then_blocking` and `conn_mut_and_then_blocking`.
- Covered the new API surface with async and blocking regression tests that exercise custom error propagation.

## Testing
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo fmt --all -- --check`