### PR TITLE
Align rusqlite feature passthroughs with 0.40 defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ All database operations use a closure-based API (e.g., `conn(|conn| { ... })`) t
 
 ## Features
 
-All Cargo features are pass-through to `rusqlite`. The `bundled` feature (default) bundles SQLite. The library re-exports `rusqlite` for downstream use.
+All Cargo features are pass-through to `rusqlite`. The `rusqlite` dependency has `default-features = false`; async-sqlite explicitly defaults to `bundled` plus rusqlite's `cache` and `ffi-sqlite-wasm-rs` defaults. The library re-exports `rusqlite` for downstream use.
 
 ## Testing
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["sqlite", "sqlite3", "rusqlite", "async", "tokio"]
 categories = ["database"]
 
 [features]
-default = ["bundled"]
+default = ["bundled", "cache", "ffi-sqlite-wasm-rs"]
 array = ["rusqlite/array"]
 backup = ["rusqlite/backup"]
 blob = ["rusqlite/blob"]
@@ -22,17 +22,26 @@ bundled-sqlcipher = ["rusqlite/bundled-sqlcipher"]
 bundled-sqlcipher-vendored-openssl = [
     "rusqlite/bundled-sqlcipher-vendored-openssl",
 ]
+cache = ["rusqlite/cache"]
 chrono = ["rusqlite/chrono"]
+collation = ["rusqlite/collation"]
 column_decltype = ["rusqlite/column_decltype"]
+column_metadata = ["rusqlite/column_metadata"]
 csv = ["rusqlite/csv"]
 csvtab = ["rusqlite/csvtab"]
 fallible_uint = ["rusqlite/fallible_uint"]
+ffi-sqlite-wasm-rs = ["rusqlite/ffi-sqlite-wasm-rs"]
 functions = ["rusqlite/functions"]
 hooks = ["rusqlite/hooks"]
+i128_blob = ["rusqlite/i128_blob"]
+jiff = ["rusqlite/jiff"]
 limits = ["rusqlite/limits"]
 load_extension = ["rusqlite/load_extension"]
 modern-full = ["rusqlite/modern-full"]
+preupdate_hook = ["rusqlite/preupdate_hook"]
 serde_json = ["rusqlite/serde_json"]
+serialize = ["rusqlite/serialize"]
+series = ["rusqlite/series"]
 session = ["rusqlite/session"]
 sqlcipher = ["rusqlite/sqlcipher"]
 time = ["rusqlite/time"]
@@ -47,7 +56,7 @@ window = ["rusqlite/window"]
 crossbeam-channel = { version = "0.5" }
 futures-channel = { version = "0.3" }
 futures-util = { version = "0.3" }
-rusqlite = { version = "0.40.0" }
+rusqlite = { version = "0.40.0", default-features = false }
 
 [dev-dependencies]
 paste = { version = "1.0.12" }

--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ println!("Value is: {value}");
 This library tries to export almost all features that the underlying
 [rusqlite](https://docs.rs/rusqlite/latest/rusqlite/) library contains.
 
-A notable difference is that the `bundled` feature is **enabled** by default,
-but can be disabled with the following line in your Cargo.toml:
+A notable difference is that the `bundled` feature is **enabled** by default
+alongside rusqlite's `cache` and `ffi-sqlite-wasm-rs` defaults. These defaults
+can be disabled with the following line in your Cargo.toml:
 
 ```toml
 async-sqlite = { version = "*", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,9 @@
 //! This library tries to export almost all features that the underlying
 //! [rusqlite](https://docs.rs/rusqlite/latest/rusqlite/) library contains.
 //!
-//! A notable difference is that the `bundled` feature is **enabled** by default,
-//! but can be disabled with the following line in your Cargo.toml:
+//! A notable difference is that the `bundled` feature is **enabled** by default
+//! alongside rusqlite's `cache` and `ffi-sqlite-wasm-rs` defaults. These defaults
+//! can be disabled with the following line in your Cargo.toml:
 //!
 //! ```toml
 //! async-sqlite = { version = "*", default-features = false }


### PR DESCRIPTION
## Summary
- Disable `rusqlite` default features at the dependency edge and model async-sqlite defaults explicitly.
- Add pass-through support for the missing public `rusqlite` features: `collation`, `column_metadata`, `i128_blob`, `jiff`, `preupdate_hook`, `serialize`, and `series`.
- Update crate docs and agent guidance to reflect the explicit default feature set.

## Testing
- `cargo check`
- `cargo check --no-default-features`
- `cargo check --no-default-features --features "bundled collation column_metadata i128_blob jiff preupdate_hook serialize series"`
- `cargo test`